### PR TITLE
Avoid empty links on anchors with uiSref

### DIFF
--- a/src/directives/uiSref.ts
+++ b/src/directives/uiSref.ts
@@ -14,7 +14,11 @@ import { Subscription } from "rxjs/Subscription";
 export class AnchorUISref {
   constructor(public _el: ElementRef, public _renderer: Renderer) { }
   update(href: string) {
-    this._renderer.setElementProperty(this._el.nativeElement, 'href', href);
+    if (href && href != '') {
+      this._renderer.setElementProperty(this._el.nativeElement, 'href', href);
+    } else {
+      this._el.nativeElement.removeAttribute('href');
+    }
   }
 }
 

--- a/test/uiSref.spec.ts
+++ b/test/uiSref.spec.ts
@@ -1,0 +1,38 @@
+import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+import { UIRouterModule } from '../src/uiRouterNgModule';
+import { UISref } from '../src/directives/uiSref';
+
+describe('uiSref', () => {
+  describe('empty links', () => {
+    @Component({
+      template: `
+        <a [uiSref]="null"></a>
+        <a [uiSref]="''"></a>
+      `
+    })
+    class TestComponent { }
+
+    let des: DebugElement[];
+    let comp: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.configureTestingModule({
+        declarations: [ TestComponent ],
+        imports:      [ UIRouterModule ]
+      }).createComponent(TestComponent);
+      fixture.detectChanges();
+      des = fixture.debugElement.queryAll(By.directive(UISref));
+    });
+
+    it('should not bind "null" string to `href`', () => {
+      expect(des[0].nativeElement.hasAttribute('href')).toBeFalsy();
+      expect(des[1].nativeElement.hasAttribute('href')).toBeFalsy();
+    });
+  });
+});
+


### PR DESCRIPTION
uiSref directives doesn't bind href on `null` or empty string '' state.

Fixes #26